### PR TITLE
Update for bilby 2.3.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,7 +31,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install .[test]
-        pip install --pre bilby==2.3.0rc0 "numpy<2"
     - name: Test with pytest
       run: |
         python -m pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
     "Programming Language :: Python :: 3",
 ]
 dependencies = [
-    "bilby",
+    "bilby>=2.3.0",
     "nessai",
     "numpy",
     "pandas",


### PR DESCRIPTION
Now that bilby 2.3.0 is on pypi we can update the requirements and start working towards a first release.