### PR TITLE
BUG: nessai_plot applies to FlowSampler and FlowSampler.run

### DIFF
--- a/src/nessai_bilby/plugin.py
+++ b/src/nessai_bilby/plugin.py
@@ -69,7 +69,7 @@ class Nessai(NestedSampler):
 
         - :code:`nessai_log_level`: allows setting the logging level in nessai
         - :code:`nessai_logging_stream`: allows setting the logging stream
-        - :code:`nessai_plot`: allows toggling the plotting in FlowSampler.run
+        - :code:`nessai_plot`: allows toggling the plotting in FlowSampler and FlowSampler.run
         - :code:`nessai_likelihood_constraint`: allows toggling between
           including the prior constraints in likelihood or the prior.
         """
@@ -124,7 +124,9 @@ class Nessai(NestedSampler):
         run_kwargs = {}
         for k in self.run_kwargs_list:
             run_kwargs[k] = kwargs.pop(k)
-        run_kwargs["plot"] = kwargs.pop("nessai_plot")
+        nessai_plot = kwargs.pop("nessai_plot")
+        kwargs["plot"] = nessai_plot
+        run_kwargs["plot"] = nessai_plot
         return kwargs, run_kwargs
 
     def get_posterior_weights(self):

--- a/tests/test_bilby_integration.py
+++ b/tests/test_bilby_integration.py
@@ -84,7 +84,7 @@ def test_sampling_nessai_plot(
         seed=1234,
         nessai_likelihood_constraint=False,
         nessai_plot=False,
-        pool=None,
+        n_pool=None,
     )
     # Assert no png files in the output directory
     assert not list(outdir.glob("*_nessai/*.png"))

--- a/tests/test_bilby_integration.py
+++ b/tests/test_bilby_integration.py
@@ -84,6 +84,7 @@ def test_sampling_nessai_plot(
         seed=1234,
         nessai_likelihood_constraint=False,
         nessai_plot=False,
+        pool=None,
     )
     # Assert no png files in the output directory
     assert not list(outdir.glob("*_nessai/*.png"))

--- a/tests/test_bilby_integration.py
+++ b/tests/test_bilby_integration.py
@@ -33,6 +33,8 @@ def test_sampling_nessai(
         nessai_likelihood_constraint=likelihood_constraint,
         n_pool=None,
     )
+    # Assert plots are made
+    assert list(outdir.glob("*_nessai/*.png"))
 
 
 def test_sampling_inessai(
@@ -58,3 +60,30 @@ def test_sampling_inessai(
         nessai_likelihood_constraint=likelihood_constraint,
         n_pool=None,
     )
+
+
+def test_sampling_nessai_plot(
+    bilby_gaussian_likelihood_and_priors,
+    tmp_path,
+):
+    likelihood, priors = bilby_gaussian_likelihood_and_priors
+
+    outdir = tmp_path / "test_sampling_nessai_plot"
+
+    bilby.run_sampler(
+        outdir=outdir,
+        resume=False,
+        plot=True,
+        likelihood=likelihood,
+        priors=priors,
+        nlive=100,
+        stopping=5.0,
+        sampler="nessai",
+        injection_parameters={"x": 0.0, "y": 0.0},
+        analytic_priors=True,
+        seed=1234,
+        nessai_likelihood_constraint=False,
+        nessai_plot=False,
+    )
+    # Assert no png files in the output directory
+    assert not list(outdir.glob("*_nessai/*.png"))


### PR DESCRIPTION
Allow the user to disable all plots using `nessai_plot`.

This argument was intended to control the `plot` argument in nessai but wasn't being passed to `FlowSampler`.